### PR TITLE
Prevent fields from being prepopulated in visitor registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,15 @@
 2. Go to Plugins > Add New > Upload Plugin.
 3. Create a zip file containing the seattle-makers-check-in-plugin.php file. It should be called seattle-makers-check-in-plugin.zip.
 4. Select the zip file, upload, install, and Activate it.
-5. In the top bar, hover over "+New" and click on New User. 
-  a. This will be the non-administrator user who has access to the check in page. It does not need a valid email address, but it does need a unique one.
-  b. In the user profile page, replace the Email field with the desired email address.
-  c. Click on Account and enter a Password. Uncheck the box for displaying the admin bar and making the account public. Hit Save, back out, hit Save on the Profile too.
-  d. If these login details are forgotten, you will need to repeat some of these instructions to reset the user who has access.
-6. Go to Dashboard > Presspoint > Dashboard > Advanced Search.
-7. Search for the new user created above by their email address.
-8. Click the triangle next to Search > Save As.
-9. Give it a sensible name like "check-in-admin-2023-04-22-1504" and allow Presspoint admins to view and edit.
+5. Go to Pages > Add New.
+6. Set the title to "Check-In".
+7. In the right pane, under Restrict Content Options > Allow, set it to Anyone (Unrestricted), and under Publish > Visibility, set it to Password Protected, enter a password and hit OK.
+8. Scroll down to Page Options > Title/Description > Set Title/Description Visibility to Hidden.
+9. Hit Publish. This page should now only be accessible after the password is entered.
 10. Go to Pages > Add New.
-11. Set the title to "Check-In".
-12. In the right pane, under Restrict Content Options > Allow, select the "check-in-admin-2023-04-22-1504" search (or whatever name you used).
-13. Scroll down to Page Options > Title/Description > Set Title/Description Visibility to Hidden.
-14. Hit Publish. This page should now only be accessible to the privilege-less user.
-15. Go to Pages > Add New.
-16. Set the title to Check-In Stats.
-17. In the right pane, under Publish > Visibility, set it to Private and hit OK.
-18. Hit Publish. This page should now only be accessible to administrators. It currently displays the database contents for the last 1000 check-ins.
+11. Set the title to Check-In Stats.
+12. In the right pane, under Publish > Visibility, set it to Private and hit OK.
+13. Hit Publish. This page should now only be accessible to administrators. It currently displays the database contents for the last 1000 check-ins.
 
 **Uninstall instructions:**
 1. Sign in with administrator Wordpress account.

--- a/seattle-makers-check-in-plugin.php
+++ b/seattle-makers-check-in-plugin.php
@@ -1,9 +1,9 @@
 <?php
     /*
     Plugin Name: Seattle Makers Check-In Plugin
-    Plugin URI: https://seattlemakers.org/
+    Plugin URI: https://github.com/seattlemakers/check-in/
     Description: To display at front desk to allow people to check into the space
-    Version: 0.0.1
+    Version: 1.0
     Author: Adi
     Author URI: https://github.com/adkeswani/
      */
@@ -53,10 +53,11 @@ function check_in_home($content)
                 <br><br><br>
                 <h6>First time in the space?</h6>
                 <button onclick=\"window.open('/interest/','_blank')\">Visitor Registration</button>
-                <button onclick=\"window.open('/memberships/#options/','_blank')\">Membership Sign-Up</button>
+                <button onclick=\"window.open('/memberships/','_blank')\">Membership Sign-Up</button>
             </div>
             <div class = \"column\">
-                <h3>Check Out</h3>
+                <h3>Who's In The Space</h3><br>
+                Click on your name to check out.
                 <form action=\"/check-in/\" method=\"post\">";
 
     $check_ins = check_in_db_get_todays_check_ins();
@@ -230,6 +231,7 @@ function check_in_db_add_check_in($user_id)
 function check_in_db_get_check_ins_all()
 {
     global $wpdb;
+
     $sql = $wpdb->prepare("
         SELECT *
         FROM {$wpdb->base_prefix}sm_check_ins
@@ -285,6 +287,14 @@ function check_in_db_add_check_out($user_id)
 function check_in_filter($content) 
 {
     if (($_SERVER['REQUEST_URI'] != '/check-in/') and ($_SERVER['REQUEST_URI'] != '/check-in-stats/'))
+    {
+        return $content;
+    }
+
+    // Returns true if password hasn't been entered yet.
+    // On false we return the content, which includes the password entry box.
+    // Password uses a cookie so we will only need to enter it once.
+    if (post_password_required())
     {
         return $content;
     }


### PR DESCRIPTION
- Password protected the page so that now we don't need a signed in user. Signed in user was causing fields to be prepopulated during in visitor registration.
- Minor fixes to links and headings